### PR TITLE
Reordered web.xml servlet elements for WebLogic

### DIFF
--- a/AtmosphereMeteorGrailsPlugin.groovy
+++ b/AtmosphereMeteorGrailsPlugin.groovy
@@ -133,8 +133,6 @@ This plugin incorporates the [Atmosphere Framework|https://github.com/Atmosphere
 					servlet {
 						"servlet-name"(name)
 						"servlet-class"(parameters.className)
-						"async-supported"("true")
-						"load-on-startup"(1)
 						if (initParams != "none") {
 							initParams?.each { param, value ->
 								"init-param" {
@@ -143,6 +141,8 @@ This plugin incorporates the [Atmosphere Framework|https://github.com/Atmosphere
 								}
 							}
 						}
+						"load-on-startup"(1)
+						"async-supported"("true")
 /*						if (environment == "test") {
 							if (servletContainerName == "jetty") {
 								"init-param" {


### PR DESCRIPTION
In order to en-happy-fy WebLogic I reordered the elements that are added to the web.xml so that they are in the order it demands.  I don't think this will break any other container, but it should probably be verified against Tomcat at least...

I think this will fix Issue #38 which I created earlier.
